### PR TITLE
Fix to Issue # 1 for broken link to Interactive rebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Look for a project's contribution instructions. If there are any, follow them.
 - If the project has tests run them!
 - Write or adapt tests as needed.
 - Add or change the documentation as needed.
-- Squash your commits into a single commit with git's [interactive rebase](https://help.github.com/articles/interactive-rebase). Create a new branch if necessary.
+- Squash your commits into a single commit with git's [interactive rebase](https://git-scm.com/docs/git-rebase). Create a new branch if necessary.
 - Push your branch to your fork on Github, the remote `origin`.
 - From your fork open a pull request in the correct branch. Target the project's `develop` branch if there is one, else go for `master`!
 - …


### PR DESCRIPTION
Fix: To Issue #1  for broken link to interactive rebase

Description - Earlier link was going to a non-existent page. Updated the link to https://git-scm.com/docs/git-rebase